### PR TITLE
Fixed dead link in mpw.md

### DIFF
--- a/content/terminology/mpw.md
+++ b/content/terminology/mpw.md
@@ -28,5 +28,5 @@ We sent [John McMaster](https://twitter.com/johndmcmaster) some chips to take a 
 
 {{< youtube gg_-dsuFY0I >}}
 
-And you can browse his [microphotographed die here](https://siliconpr0n.org/map/gsky/mpw1-00010001/mz_mit10x/#x=2094&y=9248&z=7)
+And you can browse his [microphotographed die here](https://siliconpr0n.org/map/gsky/mpw1-00010001/mcmaster_mz_mit10x/#x=2094&y=9248&z=7)
 


### PR DESCRIPTION
The link to the microphotographed die is broken. Updated to working one.

Old one:
![{11AA6361-7EE1-4F50-8005-B983728BDB1A}](https://github.com/user-attachments/assets/95a50ed7-895b-478f-8bb5-b9655386cc82)
