### PR TITLE
Clarification about corners

### DIFF
--- a/content/terminology/corner.md
+++ b/content/terminology/corner.md
@@ -26,6 +26,8 @@ The corners represent the most extreme variations of these parameters. By combin
 * FS (fast slow)
 * TT (typical typical)
 
+In practice, libraries also have custom corners apart from these combinations. These take things like aging, parasitics, leakage, etc. into account.
+
 We have [SPICE models](/terminology/spice) of the different corners provided in the [Skywater PDK](/terminology/pdk).
 
 ![corners included in spice file](/corners.png)


### PR DESCRIPTION
Been reading through some `.lib` files lately and read about how process nodes can define custom corners apart from the typical Process, Voltage & Temperature trio.

Might be helpful for people to know foundries will provide simulations of whatever other corners might be useful apart from the usual SS, TT, etc. combos