### PR TITLE
Add FPGA Resource link for ULX3S

### DIFF
--- a/content/resources.md
+++ b/content/resources.md
@@ -50,6 +50,6 @@ tags: ["course"]
 
 # FPGA
 
-* FPGA boards: [iCEBreaker](https://www.crowdsupply.com/1bitsquared/icebreaker-fpga), [TinyFPGA](https://tinyfpga.com/), [Black Ice](https://www.tindie.com/products/Folknology/blackice-mx/)
+* FPGA boards: [iCEBreaker](https://www.crowdsupply.com/1bitsquared/icebreaker-fpga), [TinyFPGA](https://tinyfpga.com/), [Black Ice](https://www.tindie.com/products/Folknology/blackice-mx/), [ULX3S](https://www.crowdsupply.com/radiona/ulx3s)
 * Will Green's [Project F](https://projectf.io/about/)
 * [WTFPGA course](https://github.com/esden/WTFpga)


### PR DESCRIPTION
Adds a link to the ULX3S board on the Resources page of the Zero to ASIC Course web site:

https://www.zerotoasiccourse.com/resources/

I'll plan to also add TT templates for the ULX3S at https://ulx3s.github.io/

See my current example: https://github.com/gojimmypi/ttsky-UART-FSM-TRNG-Lab/tree/main/ulx3s